### PR TITLE
fix: invalid parameter error when updating firewall rule protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ windows = { version = "0.61", features = [
 windows-result = "0.3"
 
 [dev-dependencies]
-serial_test = "3.2"
 ipconfig = "0.3"
+serial_test = "3.2"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,21 @@ use windows::{
     },
 };
 
-use crate::{constants::DWCOINIT, WindowsFirewallError};
+use crate::{constants::DWCOINIT, ProtocolFirewallWindows, WindowsFirewallError};
+
+pub fn is_not_icmp(protocol: &ProtocolFirewallWindows) -> bool {
+    !matches!(
+        protocol,
+        ProtocolFirewallWindows::Icmpv4 | ProtocolFirewallWindows::Icmpv6
+    )
+}
+
+pub fn is_not_tcp_or_udp(protocol: &ProtocolFirewallWindows) -> bool {
+    !matches!(
+        protocol,
+        ProtocolFirewallWindows::Udp | ProtocolFirewallWindows::Tcp
+    )
+}
 
 pub fn to_string_hashset<T, I>(items: I) -> HashSet<String>
 where


### PR DESCRIPTION
Fixes #7 

When calling update_rule(), the update occasionally fails with the error “The parameter is incorrect.” This happens when trying to modify the protocol field of an existing rule that was previously created with a specific protocol (ICMP, TCP, or UDP). Windows Firewall does not allow certain fields, such as ports or ICMP types, to be set depending on the selected protocol.

This PR adds conditional logic to prevent setting invalid fields during an update:
- If the target protocol is not TCP or UDP, local_ports and remote_ports are removed from the rule.
- If the protocol is not ICMP, icmp_types_and_codes is removed.

This ensures compatibility with Windows Firewall constraints and prevents the parameter error during rule updates.
